### PR TITLE
Security: Override axios to 1.12.0 to fix DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "peerDependencies": {
         "n8n-workflow": "*"
     },
-    "dependencies": {}
+    "dependencies": {},
+    "overrides": {
+        "axios": "1.12.0"
+    }
 }


### PR DESCRIPTION
# Security: Override axios to 1.12.0 to fix DoS vulnerability

## Summary
Added npm package override to force axios to version 1.12.0 across all dependencies to address a reported DoS vulnerability. The n8n-nodes-crossmint package currently uses axios@1.8.2 as a transitive dependency through n8n-workflow, and this override ensures the secure version is used instead.

## Review & Testing Checklist for Human
- [ ] **Verify override takes effect**: Run `npm install` and check that axios resolves to 1.12.0 in node_modules or package-lock.json
- [ ] **Test n8n node functionality**: Install this package in an n8n instance and verify that both CrossmintWallets and CrossmintCheckout nodes still function correctly
- [ ] **Validate HTTP requests**: Test that API calls to Crossmint services work properly with the new axios version (create test wallets, process checkout flows)

### Notes
- This is part of a coordinated security upgrade across multiple Crossmint repositories to fix the same axios DoS vulnerability
- axios 1.12.0 should be backward compatible with 1.8.2, but dependency overrides can sometimes cause unexpected behavior
- The change only affects the resolved version of axios - no code changes were made to the actual n8n node implementations

---
**Session**: https://app.devin.ai/sessions/bf609251d888444a94f5721a1ad5292c  
**Requested by**: @soinclined